### PR TITLE
Display service name

### DIFF
--- a/classes/class-wc-shipping-method-bring.php
+++ b/classes/class-wc-shipping-method-bring.php
@@ -51,6 +51,8 @@ class WC_Shipping_Method_Bring extends WC_Shipping_Method {
     $this->vat          = $this->settings['vat'];
     $this->evarsling    = $this->settings['evarsling'];
     $this->services     = $this->settings['services'];
+    $this->display_rate = $this->settings['display_rate'];
+    $this->display_desc = $this->settings['display_desc'];
     $this->max_products = ! empty( $this->settings['max_products'] ) ? (int)$this->settings['max_products'] : self::DEFAULT_MAX_PRODUCTS;
     // Extra safety, in case shop owner blanks ('') the value.
     if ( ! empty( $this->settings['alt_flat_rate'] ) ) {
@@ -212,6 +214,23 @@ class WC_Shipping_Method_Bring extends WC_Shipping_Method {
             'css'     => 'width: 450px;',
             'default' => '',
             'options' => $services
+        ),
+        'display_rate' => array(
+            'title'       => 'Display Service As',
+            'type'        => 'select',
+            'description' => 'The information about the service displayed to the customer',
+            'default'     => 'DisplayName',
+            'options' => array(
+                'DisplayName'     => 'Display Name',
+                'ProductName'     => 'Product Name'
+            )
+        ),
+        'display_desc' => array(
+            'title'       => 'Display Description',
+            'type'        => 'checkbox',
+            'label'       => 'Add description after the service',
+            'description' => 'Show service description after the name of the service',
+            'default'     => 'no'
         ),
         'max_products'  => array(
             'title'       => __( 'Max products', self::TEXT_DOMAIN ),
@@ -405,7 +424,7 @@ class WC_Shipping_Method_Bring extends WC_Shipping_Method {
       $rate = array(
           'id'    => $this->id . ':' . sanitize_title( $serviceDetails['ProductId'] ),
           'cost'  => round( $rate ) + (int)$this->fee,
-          'label' => $serviceDetails['GuiInformation']['DisplayName'],
+          'label' => $serviceDetails['GuiInformation'][$this->display_rate] . ( $this->display_desc == 'no' ? '' : ': ' . $serviceDetails['GuiInformation']['DescriptionText'] ),
       );
 
       array_push( $rates, $rate );

--- a/classes/class-wc-shipping-method-bring.php
+++ b/classes/class-wc-shipping-method-bring.php
@@ -102,28 +102,24 @@ class WC_Shipping_Method_Bring extends WC_Shipping_Method {
         'BPAKKE_DOR-DOR'               => 'Bedriftspakke',
         'EKSPRESS09'                   => 'Bedriftspakke Ekspress-Over natten 09',
         'MINIPAKKE'                    => 'Minipakken',
-        'A-POST'                       => 'A-Prioritert 1',
-        'B-POST'                       => 'B-Økonomi 2',
-        'QUICKPACK_SAMEDAY'            => 'QuickPack SameDay 3',
-        'QUICKPACK_OVER_NIGHT_0900'    => 'Quickpack Over Night 0900',
-        'QUICKPACK_OVER_NIGHT_1200'    => 'Quickpack Over Night 1200',
-        'QUICKPACK_DAY_CERTAIN'        => 'Quickpack Day Certain',
-        'QUICKPACK_EXPRESS_ECONOMY'    => 'Quickpack Express Economy',
+        'A-POST'                       => 'A-Prioritert',
+        'B-POST'                       => 'B-Økonomi',
+        'SMAAPAKKER_A-POST'            => 'Småpakke A-Post',
+        'SMAAPAKKER_B-POST'            => 'Småpakke B-Post',
+        'EXPRESS_NORDIC_SAME_DAY'      => 'Express Nordic Same Day',
+        'EXPRESS_INTERNATIONAL_0900'   => 'Express International 09:00',
+        'EXPRESS_INTERNATIONAL_1200'   => 'Express International 12:00',
+        'EXPRESS_INTERNATIONAL'        => 'Express International',
+        'EXPRESS_ECONOMY'              => 'Express Economy',
         'CARGO_GROUPAGE'               => 'Cargo',
-        'CARRYON BUSINESS NORWAY'      => 'CarryOn Business Norway',
-        'CARRYON BUSINESS SWEDEN'      => 'CarryOn Business Sweden',
-        'CARRYON BUSINESS DENMARK'     => 'CarryOn Business Denmark',
-        'CARRYON BUSINESS FINLAND'     => 'CarryOn Business Finland',
-        'CARRYON HOMESHOPPING NORWAY'  => 'CarryOn Homeshopping Norway',
-        'CARRYON HOMESHOPPING SWEDEN'  => 'CarryOn Homeshopping Sweden',
-        'CARRYON HOMESHOPPING DENMARK' => 'CarryOn Homeshopping Denmark',
-        'CARRYON HOMESHOPPING FINLAND' => 'CarryOn Homeshopping Finland',
-        'HOMEDELIVERY_CURBSIDE_DAG'    => 'HomeDelivery CurbSide',
+        'BUSINESS_PARCEL'              => 'Business Parcel',
+        'PICKUP_PARCEL'                => 'PickUp Parcel',
         'COURIER_VIP'                  => 'Bud VIP',
         'COURIER_1H'                   => 'Bud 1 time',
         'COURIER_2H'                   => 'Bud 2 timer',
         'COURIER_4H'                   => 'Bud 4 timer',
         'COURIER_6H'                   => 'Bud 6 timer',
+        'OIL_EXPRESS'                  => 'Oil Express',
     );
 
     $wc_log_dir = '';
@@ -231,7 +227,7 @@ class WC_Shipping_Method_Bring extends WC_Shipping_Method {
             'label'       => 'Add description after the service',
             'description' => 'Show service description after the name of the service',
             'default'     => 'no'
-        ),
+        ),                
         'max_products'  => array(
             'title'       => __( 'Max products', self::TEXT_DOMAIN ),
             'type'        => 'text',
@@ -374,7 +370,7 @@ class WC_Shipping_Method_Bring extends WC_Shipping_Method {
       // Filter the response json to get only the selected services from the settings.
       $rates = $this->get_services_from_response( $json );
 
-      if ( $this->debug != 'no' ) {
+      if ( $this->debug != 'no' ) {     
         $this->log->add( $this->id, 'params: ' . print_r( $params, true ) );
 
         if ( $rates ) {


### PR DESCRIPTION
My first try at gitcommit :) Two commits, first one:
The display-name of the services was weird for us at checkout.  …
Added two settings:
1 - To choose to display either DisplayName of ProductName
2 - To optionally append DescriptionText afther the display text.

Second is an update of the available services based on our previous conversation on Wordpress.org