### PR TITLE
Add support for WooCommerce 2.6 shipping zones

### DIFF
--- a/bring-fraktguiden-for-woocommerce.php
+++ b/bring-fraktguiden-for-woocommerce.php
@@ -65,7 +65,7 @@ class Bring_Fraktguiden {
    * @return array
    */
   static function add_bring_method( $methods ) {
-    $methods[] = class_exists( 'WC_Shipping_Method_Bring_Pro' ) ? 'WC_Shipping_Method_Bring_Pro' : 'WC_Shipping_Method_Bring';
+    $methods['bring_fraktguiden'] = class_exists( 'WC_Shipping_Method_Bring_Pro' ) ? 'WC_Shipping_Method_Bring_Pro' : 'WC_Shipping_Method_Bring';
     return $methods;
   }
 

--- a/classes/class-wc-shipping-method-bring.php
+++ b/classes/class-wc-shipping-method-bring.php
@@ -35,6 +35,8 @@ class WC_Shipping_Method_Bring extends WC_Shipping_Method {
 
   const DEFAULT_ALT_FLAT_RATE = 200;
 
+  public $supports = [ 'shipping-zones', 'settings' ];
+
   private $from_country = '';
   private $from_zip = '';
   private $post_office = '';
@@ -57,8 +59,12 @@ class WC_Shipping_Method_Bring extends WC_Shipping_Method {
 
   /**
    * @constructor
+   *
+   * @param int $instance_id
    */
-  public function __construct() {
+  public function __construct( $instance_id = 0 ) {
+    parent::__construct( $instance_id );
+
     $this->id           = self::ID;
     $this->method_title = __( 'Bring Fraktguiden', self::TEXT_DOMAIN );
 
@@ -495,7 +501,7 @@ class WC_Shipping_Method_Bring extends WC_Shipping_Method {
       $this->add_rate( $rate );
     }
     else {
-      $cart = $woocommerce->cart->get_cart();
+      $cart = $package[ 'contents'];
       $this->packages_params = $this->pack_order( $cart );
       if ( ! $this->packages_params ) {
         return;
@@ -508,7 +514,7 @@ class WC_Shipping_Method_Bring extends WC_Shipping_Method {
       }
 
       // Request parameters.
-      $params = array_merge( $this->create_standard_url_params(), $this->packages_params );
+      $params = array_merge( $this->create_standard_url_params( $package ), $this->packages_params );
       // Remove any empty elements.
       $params = array_filter( $params );
 
@@ -598,16 +604,18 @@ class WC_Shipping_Method_Bring extends WC_Shipping_Method {
   /**
    * Standard url params for the Bring http request.
    *
+   * @param $package
+   *
    * @return array
    */
-  public function create_standard_url_params() {
+  public function create_standard_url_params( $package ) {
     global $woocommerce;
     return apply_filters( 'bring_fraktguiden_standard_url_params', array(
         'clientUrl'           => $_SERVER['HTTP_HOST'],
         'from'                => $this->from_zip,
         'fromCountry'         => $this->get_selected_from_country(),
-        'to'                  => $woocommerce->customer->get_shipping_postcode(),
-        'toCountry'           => $woocommerce->customer->get_shipping_country(),
+        'to'                  => $package[ 'destination' ][ 'postcode' ],
+        'toCountry'           => $package[ 'destination' ][ 'country' ],
         'postingAtPostOffice' => ( $this->post_office == 'no' ) ? 'false' : 'true',
         'additional'          => ( $this->evarsling == 'yes' ) ? 'evarsling' : '',
     ) );

--- a/pro/class-wc-shipping-method-bring-pro.php
+++ b/pro/class-wc-shipping-method-bring-pro.php
@@ -38,9 +38,9 @@ class WC_Shipping_Method_Bring_Pro extends WC_Shipping_Method_Bring {
   private $booking_address_email;
   private $booking_test_mode;
 
-  public function __construct() {
+  public function __construct($instance_id = 0) {
 
-    parent::__construct();
+    parent::__construct($instance_id);
 
     $this->title        = __( 'Bring Fraktguiden Pro', self::TEXT_DOMAIN );
     $this->method_title = __( 'Bring Fraktguiden Pro', self::TEXT_DOMAIN );

--- a/pro/class-wc-shipping-method-bring-pro.php
+++ b/pro/class-wc-shipping-method-bring-pro.php
@@ -38,9 +38,9 @@ class WC_Shipping_Method_Bring_Pro extends WC_Shipping_Method_Bring {
   private $booking_address_email;
   private $booking_test_mode;
 
-  public function __construct($instance_id = 0) {
+  public function __construct( $instance_id = 0 ) {
 
-    parent::__construct($instance_id);
+    parent::__construct( $instance_id );
 
     $this->title        = __( 'Bring Fraktguiden Pro', self::TEXT_DOMAIN );
     $this->method_title = __( 'Bring Fraktguiden Pro', self::TEXT_DOMAIN );


### PR DESCRIPTION
The current master branch does not support shipping zones introduced in WooCommerce 2.6. This commit adds the minimum amount of code to get shipping zones working, allowing Bring to be added as a shipping method to a zone.
